### PR TITLE
[FEAT] 운영자 페이지 분리 및 Ops 페이지 구조 개선

### DIFF
--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -35,3 +35,6 @@ export const retryAdminOperation = (body) =>
 
 export const cancelAdminOperation = (body) =>
     api.post("/admin/operations/cancel", body);
+
+export const getAdminOperationTargetDetail = (params) =>
+    api.get("/admin/operations/target", { params });

--- a/src/components/admin/AdminSidebar.jsx
+++ b/src/components/admin/AdminSidebar.jsx
@@ -76,9 +76,6 @@ function AdminSidebar() {
                 <NavLink to="/ops/issues" style={menuStyle}>
                     Error Issues
                 </NavLink>
-                <NavLink to="/ops/logs" style={menuStyle}>
-                    Error Logs
-                </NavLink>
             </div>
 
             <div>

--- a/src/pages/admin/AdminOperationsPage.jsx
+++ b/src/pages/admin/AdminOperationsPage.jsx
@@ -1,9 +1,382 @@
-import AdminLayout from "../../components/admin/AdminLayout";
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import {
+    Alert,
+    Badge,
+    Button,
+    Card,
+    Col,
+    Form,
+    Row,
+    Spinner
+} from "react-bootstrap";
+import AdminLayout from "../../components/admin/AdminLayout.jsx";
+import {
+    getAdminOperationTargetDetail,
+    retryAdminOperation,
+    cancelAdminOperation
+} from "../../api/admin.js";
 
 function AdminOperationsPage() {
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+
+    const [targetType, setTargetType] = useState("ANALYSIS_REPORT");
+    const [targetId, setTargetId] = useState("");
+    const [reason, setReason] = useState("");
+
+    const [detail, setDetail] = useState(null);
+
+    const [loadingDetail, setLoadingDetail] = useState(false);
+    const [submittingRetry, setSubmittingRetry] = useState(false);
+    const [submittingCancel, setSubmittingCancel] = useState(false);
+
+    const [error, setError] = useState("");
+    const [successMessage, setSuccessMessage] = useState("");
+
+    useEffect(() => {
+        const qsTargetType = searchParams.get("targetType");
+        const qsTargetId = searchParams.get("targetId");
+
+        if (qsTargetType) {
+            setTargetType(qsTargetType);
+        }
+
+        if (qsTargetId) {
+            setTargetId(qsTargetId);
+            fetchTargetDetail(qsTargetType || "ANALYSIS_REPORT", qsTargetId);
+        }
+    }, []);
+
+    const fetchTargetDetail = async (type = targetType, id = targetId) => {
+        if (!id) {
+            setError("대상 ID를 입력해주세요.");
+            setDetail(null);
+            return;
+        }
+
+        try {
+            setLoadingDetail(true);
+            setError("");
+            setSuccessMessage("");
+
+            const res = await getAdminOperationTargetDetail({
+                targetType: type,
+                targetId: Number(id)
+            });
+
+            const payload = res.data?.data ?? res.data;
+            setDetail(payload);
+        } catch (e) {
+            console.error("운영 제어 대상 조회 실패:", e);
+            setDetail(null);
+            setError(
+                e.response?.data?.message ||
+                "대상 정보를 불러오지 못했습니다."
+            );
+        } finally {
+            setLoadingDetail(false);
+        }
+    };
+
+    const handleSearch = async (e) => {
+        e.preventDefault();
+        fetchTargetDetail();
+    };
+
+    const handleRetry = async () => {
+        if (!detail) return;
+
+        try {
+            setSubmittingRetry(true);
+            setError("");
+            setSuccessMessage("");
+
+            const body = {
+                targetType: detail.targetType,
+                targetId: detail.targetId,
+                reason: reason || "관리자 재처리 요청"
+            };
+
+            const res = await retryAdminOperation(body);
+            const payload = res.data?.data ?? res.data;
+
+            setSuccessMessage(
+                `${payload.targetType} #${payload.targetId} 재처리 요청이 접수되었습니다.`
+            );
+
+            await fetchTargetDetail(detail.targetType, detail.targetId);
+        } catch (e) {
+            console.error("재처리 요청 실패:", e);
+            setError(
+                e.response?.data?.message ||
+                "재처리 요청에 실패했습니다."
+            );
+        } finally {
+            setSubmittingRetry(false);
+        }
+    };
+
+    const handleCancel = async () => {
+        if (!detail) return;
+
+        try {
+            setSubmittingCancel(true);
+            setError("");
+            setSuccessMessage("");
+
+            const body = {
+                targetType: detail.targetType,
+                targetId: detail.targetId,
+                reason: reason || "관리자 취소 요청"
+            };
+
+            const res = await cancelAdminOperation(body);
+            const payload = res.data?.data ?? res.data;
+
+            setSuccessMessage(
+                `${payload.targetType} #${payload.targetId} 취소 요청이 접수되었습니다.`
+            );
+
+            await fetchTargetDetail(detail.targetType, detail.targetId);
+        } catch (e) {
+            console.error("취소 요청 실패:", e);
+            setError(
+                e.response?.data?.message ||
+                "취소 요청에 실패했습니다."
+            );
+        } finally {
+            setSubmittingCancel(false);
+        }
+    };
+
+    const renderStatusBadge = (value) => {
+        if (!value) return <Badge bg="secondary">-</Badge>;
+
+        const upper = String(value).toUpperCase();
+
+        if (upper === "SUCCESS" || upper === "COMPLETED") {
+            return <Badge bg="success">{value}</Badge>;
+        }
+
+        if (upper === "FAILED" || upper === "CANCELLED") {
+            return <Badge bg="danger">{value}</Badge>;
+        }
+
+        if (upper === "PROCESSING") {
+            return <Badge bg="primary">{value}</Badge>;
+        }
+
+        if (upper === "ENQUEUED" || upper === "PENDING" || upper === "DELAYED") {
+            return <Badge bg="warning" text="dark">{value}</Badge>;
+        }
+
+        return <Badge bg="secondary">{value}</Badge>;
+    };
+
+    const formatDateTime = (value) => {
+        if (!value) return "-";
+        try {
+            return new Date(value).toLocaleString("ko-KR");
+        } catch {
+            return value;
+        }
+    };
+
+    const hasLinkedUser =
+        detail?.memberId || detail?.memberEmail || detail?.memberNickname;
+
     return (
         <AdminLayout title="운영 제어">
-            <div>관리자 재처리 및 강제 취소 기능을 제공하는 페이지입니다.</div>
+            <Card className="shadow-sm border-0 mb-4">
+                <Card.Body>
+                    <div className="mb-3">
+                        <h5 className="mb-1">작업 대상 조회</h5>
+                        <div className="text-muted small">
+                            에러 로그 또는 이슈 화면에서 넘어온 대상 ID를 조회해 현재 상태를 확인하고,
+                            필요한 경우 재처리 또는 취소를 수행합니다.
+                        </div>
+                    </div>
+
+                    <Form onSubmit={handleSearch}>
+                        <Row className="g-3 align-items-end">
+                            <Col md={3}>
+                                <Form.Label>대상 유형</Form.Label>
+                                <Form.Select
+                                    value={targetType}
+                                    onChange={(e) => setTargetType(e.target.value)}
+                                >
+                                    <option value="ANALYSIS_REPORT">ANALYSIS_REPORT</option>
+                                </Form.Select>
+                            </Col>
+
+                            <Col md={3}>
+                                <Form.Label>대상 ID</Form.Label>
+                                <Form.Control
+                                    type="number"
+                                    value={targetId}
+                                    onChange={(e) => setTargetId(e.target.value)}
+                                    placeholder="예: 15"
+                                />
+                            </Col>
+
+                            <Col md={4}>
+                                <Form.Label>사유 (선택)</Form.Label>
+                                <Form.Control
+                                    type="text"
+                                    value={reason}
+                                    onChange={(e) => setReason(e.target.value)}
+                                    placeholder="재처리 또는 취소 사유"
+                                />
+                            </Col>
+
+                            <Col md={2}>
+                                <Button type="submit" className="w-100" disabled={loadingDetail}>
+                                    {loadingDetail ? "조회 중..." : "상세 조회"}
+                                </Button>
+                            </Col>
+                        </Row>
+                    </Form>
+                </Card.Body>
+            </Card>
+
+            {error && (
+                <Alert variant="danger" className="mb-4">
+                    {error}
+                </Alert>
+            )}
+
+            {successMessage && (
+                <Alert variant="success" className="mb-4">
+                    {successMessage}
+                </Alert>
+            )}
+
+            {loadingDetail && (
+                <div className="text-center py-5">
+                    <Spinner animation="border" />
+                </div>
+            )}
+
+            {!loadingDetail && detail && (
+                <>
+                    <Card className="shadow-sm border-0 mb-4">
+                        <Card.Body>
+                            <div className="d-flex justify-content-between align-items-start flex-wrap gap-2 mb-3">
+                                <div>
+                                    <h5 className="mb-1">대상 상세 정보</h5>
+                                    <div className="text-muted small">
+                                        조회한 대상의 현재 처리 상태와 최근 큐 상태를 확인할 수 있습니다.
+                                    </div>
+                                </div>
+
+                                <div className="d-flex gap-2 flex-wrap">
+                                    {detail.targetType && detail.targetId && (
+                                        <Button
+                                            variant="outline-secondary"
+                                            size="sm"
+                                            onClick={() =>
+                                                navigate(`/ops/logs?targetType=${encodeURIComponent(detail.targetType)}&targetId=${detail.targetId}`)
+                                            }
+                                            disabled
+                                        >
+                                            연관 로그 조회 준비
+                                        </Button>
+                                    )}
+                                </div>
+                            </div>
+
+                            <Row className="g-3">
+                                <Col md={6}>
+                                    <div className="border rounded p-3 h-100">
+                                        <div className="text-muted small mb-2">작업 기본 정보</div>
+                                        <div className="mb-2"><strong>대상 유형:</strong> {detail.targetType}</div>
+                                        <div className="mb-2"><strong>대상 ID:</strong> {detail.targetId}</div>
+                                        <div className="mb-2"><strong>현재 상태:</strong> {renderStatusBadge(detail.currentStatus)}</div>
+                                        <div className="mb-2"><strong>최근 큐 상태:</strong> {renderStatusBadge(detail.latestQueueStatus)}</div>
+                                        <div className="mb-2"><strong>재시도 횟수:</strong> {detail.retryCount ?? 0}</div>
+                                        <div className="mb-0"><strong>마지막 처리 시각:</strong> {formatDateTime(detail.lastProcessedAt)}</div>
+                                    </div>
+                                </Col>
+
+                                <Col md={6}>
+                                    <div className="border rounded p-3 h-100">
+                                        <div className="text-muted small mb-2">연관 사용자 / 최근 오류</div>
+                                        <div className="mb-2"><strong>회원 ID:</strong> {detail.memberId ?? "-"}</div>
+                                        <div className="mb-2"><strong>이메일:</strong> {detail.memberEmail ?? "-"}</div>
+                                        <div className="mb-2"><strong>닉네임:</strong> {detail.memberNickname ?? "-"}</div>
+                                        <div className="mb-0">
+                                            <strong>최근 오류 메시지:</strong>
+                                            <div className="mt-1 small text-break">
+                                                {detail.latestErrorMessage || "-"}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </Col>
+                            </Row>
+
+                            <div className="mt-3">
+                                <small className="text-muted">
+                                    {!hasLinkedUser
+                                        ? "이 대상은 현재 사용자 정보가 연결되지 않았거나, 로그에 사용자 정보가 기록되지 않았습니다."
+                                        : "연관 사용자 정보가 함께 확인됩니다."}
+                                </small>
+                            </div>
+                        </Card.Body>
+                    </Card>
+
+                    <Card className="shadow-sm border-0">
+                        <Card.Body>
+                            <h5 className="mb-3">작업 제어</h5>
+
+                            <Row className="g-3 mb-3">
+                                <Col md={6}>
+                                    <div className="border rounded p-3 h-100">
+                                        <div className="fw-semibold mb-2">재처리</div>
+                                        <div className="text-muted small">
+                                            실패, 지연, 취소 상태의 작업을 다시 실행 대상으로 돌려보낼 때 사용합니다.
+                                            보통 일시적인 외부 API 오류, 큐 처리 누락, 복구 후 재실행 상황에서 사용합니다.
+                                        </div>
+                                    </div>
+                                </Col>
+
+                                <Col md={6}>
+                                    <div className="border rounded p-3 h-100">
+                                        <div className="fw-semibold mb-2">취소</div>
+                                        <div className="text-muted small">
+                                            아직 완료되지 않은 작업을 더 이상 진행하지 않도록 중단할 때 사용합니다.
+                                            중복 요청, 잘못된 입력, 운영자가 의도적으로 중단해야 하는 상황에 사용합니다.
+                                        </div>
+                                    </div>
+                                </Col>
+                            </Row>
+
+                            <div className="d-flex gap-2 flex-wrap">
+                                <Button
+                                    variant="primary"
+                                    onClick={handleRetry}
+                                    disabled={!detail.retryable || submittingRetry}
+                                >
+                                    {submittingRetry ? "재처리 요청 중..." : "재처리"}
+                                </Button>
+
+                                <Button
+                                    variant="outline-danger"
+                                    onClick={handleCancel}
+                                    disabled={!detail.cancellable || submittingCancel}
+                                >
+                                    {submittingCancel ? "취소 요청 중..." : "취소"}
+                                </Button>
+                            </div>
+
+                            <div className="mt-3 small text-muted">
+                                {!detail.retryable && "현재 상태에서는 재처리가 불가능합니다. "}
+                                {!detail.cancellable && "현재 상태에서는 취소가 불가능합니다."}
+                            </div>
+                        </Card.Body>
+                    </Card>
+                </>
+            )}
         </AdminLayout>
     );
 }

--- a/src/pages/ops/OpsAlertsPage.jsx
+++ b/src/pages/ops/OpsAlertsPage.jsx
@@ -1,9 +1,98 @@
-import AdminLayout from "../../components/admin/AdminLayout";
+import { useEffect, useState } from "react";
+import { Alert, Badge, Card, Spinner, Table } from "react-bootstrap";
+import AdminLayout from "../../components/admin/AdminLayout.jsx";
+import { getOpsAlerts } from "../../api/ops.js";
 
 function OpsAlertsPage() {
+    const [alerts, setAlerts] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        fetchAlerts();
+    }, []);
+
+    const fetchAlerts = async () => {
+        try {
+            setLoading(true);
+            setError("");
+
+            const response = await getOpsAlerts();
+            const payload = response.data?.data ?? response.data;
+            setAlerts(Array.isArray(payload) ? payload : []);
+        } catch (err) {
+            console.error("운영 알림 조회 실패:", err);
+            setError("운영 알림 데이터를 불러오지 못했습니다.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const renderLevelBadge = (level) => {
+        switch (level) {
+            case "CRITICAL":
+                return <Badge bg="danger">CRITICAL</Badge>;
+            case "HIGH":
+                return <Badge bg="warning" text="dark">HIGH</Badge>;
+            case "MEDIUM":
+                return <Badge bg="primary">MEDIUM</Badge>;
+            default:
+                return <Badge bg="secondary">{level || "INFO"}</Badge>;
+        }
+    };
+
     return (
-        <AdminLayout title="운영 알림">
-            <div>임계치 초과, 실패율 급증, 큐 적체 알림을 표시할 페이지입니다.</div>
+        <AdminLayout title="Alerts">
+            <Card className="border-0 shadow-sm mb-4">
+                <Card.Body>
+                    <h5 className="mb-2">운영 알림 안내</h5>
+                    <div className="text-muted" style={{ fontSize: "14px", lineHeight: 1.7 }}>
+                        Alerts는 운영 중 즉시 확인이 필요한 이상 징후를 보여주는 화면입니다.
+                        현재는 큐 실패 건수, 실패율, 미해결 Critical 이슈를 기준으로 경보를 생성합니다.
+                    </div>
+                </Card.Body>
+            </Card>
+
+            {error && <Alert variant="danger">{error}</Alert>}
+
+            {loading ? (
+                <div className="text-center py-5">
+                    <Spinner animation="border" />
+                </div>
+            ) : (
+                <Card className="border-0 shadow-sm">
+                    <Card.Body>
+                        <Table responsive bordered hover>
+                            <thead>
+                            <tr>
+                                <th>레벨</th>
+                                <th>유형</th>
+                                <th>메시지</th>
+                                <th>관련 ID</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {alerts.length === 0 ? (
+                                <tr>
+                                    <td colSpan="4" className="text-center">
+                                        현재 발생한 운영 알림이 없습니다.
+                                    </td>
+                                </tr>
+                            ) : (
+                                alerts.map((alertItem, idx) => (
+                                    <tr key={idx}>
+                                        <td>{renderLevelBadge(alertItem.level)}</td>
+                                        <td>{alertItem.type}</td>
+                                        <td>{alertItem.message}</td>
+                                        <td>{alertItem.relatedId ?? "-"}</td>
+                                    </tr>
+                                ))
+                            )}
+                            </tbody>
+                        </Table>
+                    </Card.Body>
+                </Card>
+            )}
         </AdminLayout>
     );
 }

--- a/src/pages/ops/OpsDashboardPage.jsx
+++ b/src/pages/ops/OpsDashboardPage.jsx
@@ -1,10 +1,136 @@
-import AdminLayout from "../../components/admin/AdminLayout";
+import { useEffect, useState } from "react";
+import { Alert, Card, Col, Row, Spinner } from "react-bootstrap";
+import AdminLayout from "../../components/admin/AdminLayout.jsx";
+import { getOpsDashboardSummary } from "../../api/ops.js";
 
 function OpsDashboardPage() {
+    const [summary, setSummary] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        fetchSummary();
+    }, []);
+
+    const fetchSummary = async () => {
+        try {
+            setLoading(true);
+            setError("");
+
+            const res = await getOpsDashboardSummary();
+            const payload = res.data?.data ?? res.data;
+            setSummary(payload);
+        } catch (e) {
+            console.error("운영 대시보드 조회 실패:", e);
+            setError("운영 대시보드 데이터를 불러오지 못했습니다.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
     return (
-        <AdminLayout title="운영 대시보드">
-            <div>운영 지표 요약, 실패율, 최근 24시간 추이를 표시할 페이지입니다.</div>
+        <AdminLayout title="운영 관제 대시보드">
+            {loading && (
+                <div className="text-center py-5">
+                    <Spinner animation="border" />
+                </div>
+            )}
+
+            {!loading && error && (
+                <Alert variant="danger">{error}</Alert>
+            )}
+
+            {!loading && !error && summary && (
+                <>
+                    <Row className="g-4 mb-4">
+                        <Col md={4} lg={2}>
+                            <SummaryCard
+                                title="오늘 에러 수"
+                                value={summary.todayErrorCount}
+                                variant="danger"
+                            />
+                        </Col>
+                        <Col md={4} lg={2}>
+                            <SummaryCard
+                                title="큐 적재"
+                                value={summary.todayQueueEnqueuedCount}
+                                variant="primary"
+                            />
+                        </Col>
+                        <Col md={4} lg={2}>
+                            <SummaryCard
+                                title="큐 성공"
+                                value={summary.todayQueueSuccessCount}
+                                variant="success"
+                            />
+                        </Col>
+                        <Col md={4} lg={2}>
+                            <SummaryCard
+                                title="큐 실패"
+                                value={summary.todayQueueFailedCount}
+                                variant="warning"
+                            />
+                        </Col>
+                        <Col md={4} lg={2}>
+                            <SummaryCard
+                                title="실패율"
+                                value={`${((summary.todayFailureRate ?? 0) * 100).toFixed(1)}%`}
+                                variant="dark"
+                            />
+                        </Col>
+                        <Col md={4} lg={2}>
+                            <SummaryCard
+                                title="OPEN CRITICAL"
+                                value={summary.openCriticalIssueCount}
+                                variant="secondary"
+                            />
+                        </Col>
+                    </Row>
+
+                    <Row className="g-4">
+                        <Col lg={6}>
+                            <Card className="shadow-sm border-0">
+                                <Card.Body>
+                                    <Card.Title className="mb-3">운영 요약</Card.Title>
+                                    <ul className="mb-0">
+                                        <li>오늘 누적 에러 수: <strong>{summary.todayErrorCount}</strong></li>
+                                        <li>오늘 큐 적재 건수: <strong>{summary.todayQueueEnqueuedCount}</strong></li>
+                                        <li>오늘 큐 성공 건수: <strong>{summary.todayQueueSuccessCount}</strong></li>
+                                        <li>오늘 큐 실패 건수: <strong>{summary.todayQueueFailedCount}</strong></li>
+                                        <li>오늘 큐 실패율: <strong>{((summary.todayFailureRate ?? 0) * 100).toFixed(1)}%</strong></li>
+                                        <li>현재 OPEN 상태의 CRITICAL 이슈: <strong>{summary.openCriticalIssueCount}</strong></li>
+                                    </ul>
+                                </Card.Body>
+                            </Card>
+                        </Col>
+
+                        <Col lg={6}>
+                            <Card className="shadow-sm border-0">
+                                <Card.Body>
+                                    <Card.Title className="mb-3">운영 해석 가이드</Card.Title>
+                                    <ul className="mb-0">
+                                        <li>큐 실패율이 높으면 AI 비동기 처리 안정성을 점검해야 합니다.</li>
+                                        <li>에러 수가 급증하면 최근 배포나 특정 기능 흐름을 함께 확인해야 합니다.</li>
+                                        <li>OPEN 상태 CRITICAL 이슈는 우선 대응 대상입니다.</li>
+                                    </ul>
+                                </Card.Body>
+                            </Card>
+                        </Col>
+                    </Row>
+                </>
+            )}
         </AdminLayout>
+    );
+}
+
+function SummaryCard({ title, value, variant = "primary" }) {
+    return (
+        <Card className="shadow-sm border-0 h-100">
+            <Card.Body>
+                <div className={`text-${variant} small fw-semibold mb-2`}>{title}</div>
+                <div style={{ fontSize: "1.8rem", fontWeight: "700" }}>{value ?? 0}</div>
+            </Card.Body>
+        </Card>
     );
 }
 

--- a/src/pages/ops/OpsIssuesPage.jsx
+++ b/src/pages/ops/OpsIssuesPage.jsx
@@ -1,10 +1,425 @@
-import AdminLayout from "../../components/admin/AdminLayout";
+import { useEffect, useState } from "react";
+import {
+    Alert,
+    Badge,
+    Button,
+    Card,
+    Col,
+    Form,
+    Modal,
+    Pagination,
+    Row,
+    Spinner,
+    Table
+} from "react-bootstrap";
+import AdminLayout from "../../components/admin/AdminLayout.jsx";
+import { getOpsIssueDetail, getOpsIssues } from "../../api/ops.js";
+import { useNavigate } from "react-router-dom";
 
 function OpsIssuesPage() {
+    const navigate = useNavigate();
+
+    const [issues, setIssues] = useState([]);
+    const [pageInfo, setPageInfo] = useState({
+        number: 0,
+        totalPages: 0,
+        totalElements: 0,
+        size: 10
+    });
+
+    const [filters, setFilters] = useState({
+        status: "",
+        severity: "",
+        errorDomain: ""
+    });
+
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    const [selectedIssue, setSelectedIssue] = useState(null);
+    const [showDetailModal, setShowDetailModal] = useState(false);
+
+    useEffect(() => {
+        fetchIssues(0, filters);
+    }, []);
+
+    const fetchIssues = async (page = 0, currentFilters = filters) => {
+        try {
+            setLoading(true);
+            setError("");
+
+            const params = {
+                ...currentFilters,
+                page,
+                size: pageInfo.size
+            };
+
+            const res = await getOpsIssues(params);
+            const payload = res.data?.data ?? res.data;
+
+            setIssues(payload.content ?? []);
+            setPageInfo({
+                number: payload.number ?? 0,
+                totalPages: payload.totalPages ?? 0,
+                totalElements: payload.totalElements ?? 0,
+                size: payload.size ?? 10
+            });
+        } catch (e) {
+            console.error("에러 이슈 목록 조회 실패:", e);
+            setError("에러 이슈 목록을 불러오지 못했습니다.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSearch = (e) => {
+        e.preventDefault();
+        fetchIssues(0, filters);
+    };
+
+    const handleReset = () => {
+        const resetFilters = {
+            status: "",
+            severity: "",
+            errorDomain: ""
+        };
+        setFilters(resetFilters);
+        fetchIssues(0, resetFilters);
+    };
+
+    const handleOpenDetail = async (issueId) => {
+        try {
+            const res = await getOpsIssueDetail(issueId);
+            const payload = res.data?.data ?? res.data;
+            setSelectedIssue(payload);
+            setShowDetailModal(true);
+        } catch (e) {
+            console.error("이슈 상세 조회 실패:", e);
+            alert("이슈 상세 정보를 불러오지 못했습니다.");
+        }
+    };
+
+    const moveToLogs = (issueId) => {
+        navigate(`/ops/logs?issueId=${issueId}`);
+    };
+
+    const moveToOperationControl = (issue) => {
+        if (!issue?.targetType || !issue?.targetId) {
+            alert("이 이슈에는 운영 제어 대상 정보가 없습니다.");
+            return;
+        }
+
+        navigate(
+            `/admin/operations?targetType=${encodeURIComponent(issue.targetType)}&targetId=${issue.targetId}`
+        );
+    };
+
     return (
-        <AdminLayout title="에러 이슈">
-            <div>Error Issue 목록과 상태 변경 기능이 들어갈 페이지입니다.</div>
+        <AdminLayout title="에러 이슈 관제">
+            <Card className="shadow-sm border-0 mb-4">
+                <Card.Body>
+                    <Form onSubmit={handleSearch}>
+                        <Row className="g-3 align-items-end">
+                            <Col md={3}>
+                                <Form.Label>상태</Form.Label>
+                                <Form.Select
+                                    value={filters.status}
+                                    onChange={(e) =>
+                                        setFilters((prev) => ({ ...prev, status: e.target.value }))
+                                    }
+                                >
+                                    <option value="">전체</option>
+                                    <option value="OPEN">OPEN</option>
+                                    <option value="IN_PROGRESS">IN_PROGRESS</option>
+                                    <option value="RESOLVED">RESOLVED</option>
+                                </Form.Select>
+                            </Col>
+
+                            <Col md={3}>
+                                <Form.Label>심각도</Form.Label>
+                                <Form.Select
+                                    value={filters.severity}
+                                    onChange={(e) =>
+                                        setFilters((prev) => ({ ...prev, severity: e.target.value }))
+                                    }
+                                >
+                                    <option value="">전체</option>
+                                    <option value="CRITICAL">CRITICAL</option>
+                                    <option value="HIGH">HIGH</option>
+                                    <option value="MEDIUM">MEDIUM</option>
+                                    <option value="LOW">LOW</option>
+                                </Form.Select>
+                            </Col>
+
+                            <Col md={3}>
+                                <Form.Label>도메인</Form.Label>
+                                <Form.Select
+                                    value={filters.errorDomain}
+                                    onChange={(e) =>
+                                        setFilters((prev) => ({ ...prev, errorDomain: e.target.value }))
+                                    }
+                                >
+                                    <option value="">전체</option>
+                                    <option value="AUTH">AUTH</option>
+                                    <option value="RESUME">RESUME</option>
+                                    <option value="INTERVIEW">INTERVIEW</option>
+                                    <option value="FILE">FILE</option>
+                                    <option value="ADMIN">ADMIN</option>
+                                    <option value="STATISTICS">STATISTICS</option>
+                                    <option value="GLOBAL">GLOBAL</option>
+                                </Form.Select>
+                            </Col>
+
+                            <Col md="auto">
+                                <Button type="submit">조회</Button>
+                            </Col>
+
+                            <Col md="auto">
+                                <Button variant="secondary" onClick={handleReset}>
+                                    초기화
+                                </Button>
+                            </Col>
+                        </Row>
+                    </Form>
+                </Card.Body>
+            </Card>
+
+            {loading && (
+                <div className="text-center py-5">
+                    <Spinner animation="border" />
+                </div>
+            )}
+
+            {!loading && error && <Alert variant="danger">{error}</Alert>}
+
+            {!loading && !error && (
+                <>
+                    <Card className="shadow-sm border-0">
+                        <Card.Body>
+                            <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+                                <div>
+                                    <Card.Title className="mb-0">이슈 목록</Card.Title>
+                                    <small className="text-muted">
+                                        같은 유형의 에러를 하나의 이슈로 묶어서 보여줍니다.
+                                    </small>
+                                </div>
+
+                                <small className="text-muted">
+                                    총 {pageInfo.totalElements}건
+                                </small>
+                            </div>
+
+                            <Table striped bordered hover responsive>
+                                <thead>
+                                <tr>
+                                    <th>이슈 ID</th>
+                                    <th>제목</th>
+                                    <th>에러 코드</th>
+                                    <th>심각도</th>
+                                    <th>상태</th>
+                                    <th>도메인</th>
+                                    <th>발생 횟수</th>
+                                    <th>최근 발생</th>
+                                    <th>액션</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {issues.length === 0 ? (
+                                    <tr>
+                                        <td colSpan="9" className="text-center">
+                                            조회된 이슈가 없습니다.
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    issues.map((issue) => (
+                                        <tr key={issue.issueId}>
+                                            <td>{issue.issueId}</td>
+                                            <td>{issue.title}</td>
+                                            <td>{issue.errorCode || "-"}</td>
+                                            <td>
+                                                <SeverityBadge severity={issue.severity} />
+                                            </td>
+                                            <td>
+                                                <StatusBadge status={issue.status} />
+                                            </td>
+                                            <td>{issue.errorDomain}</td>
+                                            <td>{issue.occurrenceCount}</td>
+                                            <td>
+                                                {issue.lastOccurredAt
+                                                    ? new Date(issue.lastOccurredAt).toLocaleString("ko-KR")
+                                                    : "-"}
+                                            </td>
+                                            <td className="d-flex gap-2 flex-wrap">
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline-primary"
+                                                    onClick={() => handleOpenDetail(issue.issueId)}
+                                                >
+                                                    상세
+                                                </Button>
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline-dark"
+                                                    onClick={() => moveToLogs(issue.issueId)}
+                                                >
+                                                    로그
+                                                </Button>
+                                            </td>
+                                        </tr>
+                                    ))
+                                )}
+                                </tbody>
+                            </Table>
+
+                            <PagingBar
+                                pageInfo={pageInfo}
+                                onMove={(page) => fetchIssues(page)}
+                            />
+                        </Card.Body>
+                    </Card>
+
+                    <IssueDetailModal
+                        show={showDetailModal}
+                        onHide={() => setShowDetailModal(false)}
+                        issue={selectedIssue}
+                        onMoveToLogs={moveToLogs}
+                        onMoveToOperationControl={moveToOperationControl}
+                    />
+                </>
+            )}
         </AdminLayout>
+    );
+}
+
+function SeverityBadge({ severity }) {
+    let bg = "secondary";
+    if (severity === "CRITICAL") bg = "danger";
+    else if (severity === "HIGH") bg = "warning";
+    else if (severity === "MEDIUM") bg = "primary";
+    else if (severity === "LOW") bg = "success";
+
+    return <Badge bg={bg}>{severity}</Badge>;
+}
+
+function StatusBadge({ status }) {
+    let bg = "secondary";
+    if (status === "OPEN") bg = "danger";
+    else if (status === "IN_PROGRESS") bg = "warning";
+    else if (status === "RESOLVED") bg = "success";
+
+    return <Badge bg={bg}>{status}</Badge>;
+}
+
+function PagingBar({ pageInfo, onMove }) {
+    if (!pageInfo || pageInfo.totalPages <= 1) return null;
+
+    const items = [];
+    for (let i = 0; i < pageInfo.totalPages; i++) {
+        items.push(
+            <Pagination.Item
+                key={i}
+                active={i === pageInfo.number}
+                onClick={() => onMove(i)}
+            >
+                {i + 1}
+            </Pagination.Item>
+        );
+    }
+
+    return (
+        <div className="d-flex justify-content-center mt-3">
+            <Pagination>
+                <Pagination.Prev
+                    disabled={pageInfo.number === 0}
+                    onClick={() => onMove(pageInfo.number - 1)}
+                />
+                {items}
+                <Pagination.Next
+                    disabled={pageInfo.number >= pageInfo.totalPages - 1}
+                    onClick={() => onMove(pageInfo.number + 1)}
+                />
+            </Pagination>
+        </div>
+    );
+}
+
+function IssueDetailModal({ show, onHide, issue, onMoveToLogs, onMoveToOperationControl }) {
+    return (
+        <Modal show={show} onHide={onHide} centered size="lg">
+            <Modal.Header closeButton>
+                <Modal.Title>이슈 상세</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                {!issue ? (
+                    <div>데이터가 없습니다.</div>
+                ) : (
+                    <div className="d-flex flex-column gap-3">
+                        <div className="border rounded p-3">
+                            <div className="text-muted small mb-2">이슈 기본 정보</div>
+                            <div className="mb-2"><strong>이슈 ID:</strong> {issue.issueId}</div>
+                            <div className="mb-2"><strong>제목:</strong> {issue.title}</div>
+                            <div className="mb-2"><strong>에러 코드:</strong> {issue.errorCode || "-"}</div>
+                            <div className="mb-2"><strong>심각도:</strong> {issue.severity}</div>
+                            <div className="mb-2"><strong>상태:</strong> {issue.status}</div>
+                            <div className="mb-2"><strong>도메인:</strong> {issue.errorDomain}</div>
+                            <div className="mb-2"><strong>발생 횟수:</strong> {issue.occurrenceCount}</div>
+                            <div className="mb-2"><strong>Fingerprint:</strong> {issue.fingerprint}</div>
+                            <div className="mb-2">
+                                <strong>최초 발생:</strong>{" "}
+                                {issue.firstOccurredAt
+                                    ? new Date(issue.firstOccurredAt).toLocaleString("ko-KR")
+                                    : "-"}
+                            </div>
+                            <div className="mb-2">
+                                <strong>최근 발생:</strong>{" "}
+                                {issue.lastOccurredAt
+                                    ? new Date(issue.lastOccurredAt).toLocaleString("ko-KR")
+                                    : "-"}
+                            </div>
+                            <div className="mb-0"><strong>최근 에러 로그 ID:</strong> {issue.lastErrorLogId ?? "-"}</div>
+                        </div>
+
+                        <div className="border rounded p-3">
+                            <div className="text-muted small mb-2">연관 대상 / 사용자</div>
+                            <div className="mb-2"><strong>대상 유형:</strong> {issue.targetType ?? "-"}</div>
+                            <div className="mb-2"><strong>대상 ID:</strong> {issue.targetId ?? "-"}</div>
+                            <div className="mb-2"><strong>연관 회원 ID:</strong> {issue.memberId ?? "-"}</div>
+                            <div className="mb-2"><strong>연관 회원 이메일:</strong> {issue.memberEmail ?? "-"}</div>
+                            <div className="mb-0"><strong>연관 회원 닉네임:</strong> {issue.memberNickname ?? "-"}</div>
+                        </div>
+
+                        <div className="d-flex gap-2 flex-wrap">
+                            <Button
+                                variant="outline-dark"
+                                onClick={() => {
+                                    onHide();
+                                    onMoveToLogs(issue.issueId);
+                                }}
+                            >
+                                이 이슈의 로그 보기
+                            </Button>
+
+                            <Button
+                                variant="primary"
+                                onClick={() => {
+                                    onHide();
+                                    onMoveToOperationControl(issue);
+                                }}
+                                disabled={!issue.targetType || !issue.targetId}
+                            >
+                                운영 제어로 이동
+                            </Button>
+                        </div>
+
+                        <div className="small text-muted">
+                            이슈 ID는 같은 유형의 에러 묶음 ID이고,
+                            최근 에러 로그 ID는 실제 원본 로그 한 건의 ID입니다.
+                            대상 ID는 실제 작업 대상 ID이며, 현재는 분석 리포트 같은 비동기 작업을 가리킵니다.
+                        </div>
+                    </div>
+                )}
+            </Modal.Body>
+        </Modal>
     );
 }
 

--- a/src/pages/ops/OpsLogsPage.jsx
+++ b/src/pages/ops/OpsLogsPage.jsx
@@ -1,10 +1,343 @@
-import AdminLayout from "../../components/admin/AdminLayout";
+import { useEffect, useState } from "react";
+import {
+    Alert,
+    Badge,
+    Button,
+    Card,
+    Modal,
+    Pagination,
+    Spinner,
+    Table
+} from "react-bootstrap";
+import AdminLayout from "../../components/admin/AdminLayout.jsx";
+import { getOpsIssueLogs, getOpsLogDetail } from "../../api/ops.js";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 function OpsLogsPage() {
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+
+    const issueId = searchParams.get("issueId");
+
+    const [logs, setLogs] = useState([]);
+    const [pageInfo, setPageInfo] = useState({
+        number: 0,
+        totalPages: 0,
+        totalElements: 0,
+        size: 10
+    });
+
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    const [selectedLog, setSelectedLog] = useState(null);
+    const [showDetailModal, setShowDetailModal] = useState(false);
+
+    useEffect(() => {
+        if (!issueId) {
+            setError("issueId가 필요합니다.");
+            setLoading(false);
+            return;
+        }
+
+        fetchLogs(0);
+    }, [issueId]);
+
+    const fetchLogs = async (page = 0) => {
+        try {
+            setLoading(true);
+            setError("");
+
+            const res = await getOpsIssueLogs(issueId, {
+                page,
+                size: pageInfo.size
+            });
+
+            const payload = res.data?.data ?? res.data;
+
+            setLogs(payload.content ?? []);
+            setPageInfo({
+                number: payload.number ?? 0,
+                totalPages: payload.totalPages ?? 0,
+                totalElements: payload.totalElements ?? 0,
+                size: payload.size ?? 10
+            });
+        } catch (e) {
+            console.error("에러 로그 목록 조회 실패:", e);
+            setError("에러 로그 목록을 불러오지 못했습니다.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleOpenDetail = async (logId) => {
+        try {
+            const res = await getOpsLogDetail(logId);
+            const payload = res.data?.data ?? res.data;
+            setSelectedLog(payload);
+            setShowDetailModal(true);
+        } catch (e) {
+            console.error("에러 로그 상세 조회 실패:", e);
+            alert("에러 로그 상세를 불러오지 못했습니다.");
+        }
+    };
+
+    const moveToOperationControl = (logItem) => {
+        if (!logItem?.targetType || !logItem?.targetId) {
+            alert("이 로그에는 운영 제어 대상 정보가 없습니다.");
+            return;
+        }
+
+        navigate(
+            `/admin/operations?targetType=${encodeURIComponent(logItem.targetType)}&targetId=${logItem.targetId}`
+        );
+    };
+
     return (
-        <AdminLayout title="에러 로그">
-            <div>개별 에러 로그 상세를 확인하는 페이지입니다.</div>
+        <AdminLayout title="에러 로그 관제">
+            <Card className="shadow-sm border-0 mb-4">
+                <Card.Body>
+                    <div className="d-flex justify-content-between align-items-start flex-wrap gap-2">
+                        <div>
+                            <Card.Title className="mb-1">이슈 로그 목록</Card.Title>
+                            <div className="text-muted small">
+                                현재 보고 있는 이슈 ID: <strong>{issueId ?? "-"}</strong>
+                            </div>
+                            <div className="text-muted small mt-1">
+                                같은 이슈로 묶인 원본 로그들을 시간순으로 확인할 수 있습니다.
+                            </div>
+                        </div>
+
+                        <Button
+                            variant="outline-secondary"
+                            size="sm"
+                            onClick={() => navigate("/ops/issues")}
+                        >
+                            이슈 목록으로 돌아가기
+                        </Button>
+                    </div>
+                </Card.Body>
+            </Card>
+
+            {loading && (
+                <div className="text-center py-5">
+                    <Spinner animation="border" />
+                </div>
+            )}
+
+            {!loading && error && <Alert variant="danger">{error}</Alert>}
+
+            {!loading && !error && (
+                <>
+                    <Card className="shadow-sm border-0">
+                        <Card.Body>
+                            <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+                                <Card.Title className="mb-0">로그 목록</Card.Title>
+                                <small className="text-muted">
+                                    총 {pageInfo.totalElements}건
+                                </small>
+                            </div>
+
+                            <Table striped bordered hover responsive>
+                                <thead>
+                                <tr>
+                                    <th>로그 ID</th>
+                                    <th>에러 코드</th>
+                                    <th>예외 타입</th>
+                                    <th>심각도</th>
+                                    <th>도메인</th>
+                                    <th>연관 사용자</th>
+                                    <th>대상</th>
+                                    <th>발생 시각</th>
+                                    <th>액션</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {logs.length === 0 ? (
+                                    <tr>
+                                        <td colSpan="9" className="text-center">
+                                            조회된 로그가 없습니다.
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    logs.map((log) => (
+                                        <tr key={log.logId}>
+                                            <td>{log.logId}</td>
+                                            <td>{log.errorCode || "-"}</td>
+                                            <td>{log.exceptionType}</td>
+                                            <td>
+                                                <SeverityBadge severity={log.severity} />
+                                            </td>
+                                            <td>{log.errorDomain}</td>
+                                            <td>{log.memberId ?? "-"}</td>
+                                            <td>
+                                                {log.targetType && log.targetId
+                                                    ? `${log.targetType} #${log.targetId}`
+                                                    : "-"}
+                                            </td>
+                                            <td>
+                                                {log.occurredAt
+                                                    ? new Date(log.occurredAt).toLocaleString("ko-KR")
+                                                    : "-"}
+                                            </td>
+                                            <td className="d-flex gap-2 flex-wrap">
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline-primary"
+                                                    onClick={() => handleOpenDetail(log.logId)}
+                                                >
+                                                    상세
+                                                </Button>
+
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline-dark"
+                                                    onClick={() => moveToOperationControl(log)}
+                                                    disabled={!log.targetType || !log.targetId}
+                                                >
+                                                    운영 제어
+                                                </Button>
+                                            </td>
+                                        </tr>
+                                    ))
+                                )}
+                                </tbody>
+                            </Table>
+
+                            <PagingBar
+                                pageInfo={pageInfo}
+                                onMove={(page) => fetchLogs(page)}
+                            />
+                        </Card.Body>
+                    </Card>
+
+                    <LogDetailModal
+                        show={showDetailModal}
+                        onHide={() => setShowDetailModal(false)}
+                        logItem={selectedLog}
+                        onMoveToOperationControl={moveToOperationControl}
+                    />
+                </>
+            )}
         </AdminLayout>
+    );
+}
+
+function SeverityBadge({ severity }) {
+    let bg = "secondary";
+    if (severity === "CRITICAL") bg = "danger";
+    else if (severity === "HIGH") bg = "warning";
+    else if (severity === "MEDIUM") bg = "primary";
+    else if (severity === "LOW") bg = "success";
+
+    return <Badge bg={bg}>{severity}</Badge>;
+}
+
+function PagingBar({ pageInfo, onMove }) {
+    if (!pageInfo || pageInfo.totalPages <= 1) return null;
+
+    const items = [];
+    for (let i = 0; i < pageInfo.totalPages; i++) {
+        items.push(
+            <Pagination.Item
+                key={i}
+                active={i === pageInfo.number}
+                onClick={() => onMove(i)}
+            >
+                {i + 1}
+            </Pagination.Item>
+        );
+    }
+
+    return (
+        <div className="d-flex justify-content-center mt-3">
+            <Pagination>
+                <Pagination.Prev
+                    disabled={pageInfo.number === 0}
+                    onClick={() => onMove(pageInfo.number - 1)}
+                />
+                {items}
+                <Pagination.Next
+                    disabled={pageInfo.number >= pageInfo.totalPages - 1}
+                    onClick={() => onMove(pageInfo.number + 1)}
+                />
+            </Pagination>
+        </div>
+    );
+}
+
+function LogDetailModal({ show, onHide, logItem, onMoveToOperationControl }) {
+    return (
+        <Modal show={show} onHide={onHide} size="lg" centered>
+            <Modal.Header closeButton>
+                <Modal.Title>로그 상세</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                {!logItem ? (
+                    <div>데이터가 없습니다.</div>
+                ) : (
+                    <div className="d-flex flex-column gap-3">
+                        <div className="border rounded p-3">
+                            <div className="text-muted small mb-2">식별 정보</div>
+                            <div className="mb-2"><strong>로그 ID:</strong> {logItem.logId}</div>
+                            <div className="mb-2"><strong>이슈 ID:</strong> {logItem.issueId ?? "-"}</div>
+                            <div className="mb-2"><strong>회원 ID:</strong> {logItem.memberId ?? "-"}</div>
+                            <div className="mb-2"><strong>에러 코드:</strong> {logItem.errorCode ?? "-"}</div>
+                            <div className="mb-0"><strong>Fingerprint:</strong> {logItem.fingerprint}</div>
+                        </div>
+
+                        <div className="border rounded p-3">
+                            <div className="text-muted small mb-2">에러 정보</div>
+                            <div className="mb-2"><strong>예외 타입:</strong> {logItem.exceptionType}</div>
+                            <div className="mb-2"><strong>심각도:</strong> {logItem.severity}</div>
+                            <div className="mb-2"><strong>도메인:</strong> {logItem.errorDomain}</div>
+                            <div className="mb-2"><strong>메시지:</strong> {logItem.message}</div>
+                            <div className="mb-0"><strong>정규화 메시지:</strong> {logItem.normalizedMessage || "-"}</div>
+                        </div>
+
+                        <div className="border rounded p-3">
+                            <div className="text-muted small mb-2">연관 대상</div>
+                            <div className="mb-2"><strong>Trace ID:</strong> {logItem.requestTraceId ?? "-"}</div>
+                            <div className="mb-2"><strong>대상 유형:</strong> {logItem.targetType ?? "-"}</div>
+                            <div className="mb-2"><strong>대상 ID:</strong> {logItem.targetId ?? "-"}</div>
+                            <div className="mb-0">
+                                <strong>발생 시각:</strong>{" "}
+                                {logItem.occurredAt
+                                    ? new Date(logItem.occurredAt).toLocaleString("ko-KR")
+                                    : "-"}
+                            </div>
+                        </div>
+
+                        <div className="d-flex gap-2 flex-wrap">
+                            <Button
+                                variant="dark"
+                                onClick={() => onMoveToOperationControl(logItem)}
+                                disabled={!logItem.targetType || !logItem.targetId}
+                            >
+                                이 로그 기준으로 운영 제어 열기
+                            </Button>
+                        </div>
+
+                        <div>
+                            <strong>Stack Trace</strong>
+                            <pre
+                                style={{
+                                    background: "#f8f9fa",
+                                    padding: "12px",
+                                    borderRadius: "8px",
+                                    maxHeight: "300px",
+                                    overflow: "auto",
+                                    whiteSpace: "pre-wrap",
+                                    marginTop: "8px"
+                                }}
+                            >
+                                {logItem.stackTrace || "-"}
+                            </pre>
+                        </div>
+                    </div>
+                )}
+            </Modal.Body>
+        </Modal>
     );
 }
 

--- a/src/pages/ops/OpsQueuePage.jsx
+++ b/src/pages/ops/OpsQueuePage.jsx
@@ -1,10 +1,383 @@
-import AdminLayout from "../../components/admin/AdminLayout";
+import { useEffect, useMemo, useState } from "react";
+import { Alert, Button, Card, Col, Form, Row, Spinner, Table } from "react-bootstrap";
+import AdminLayout from "../../components/admin/AdminLayout.jsx";
+import { getOpsQueueHourly, getOpsQueueSummary } from "../../api/ops.js";
 
 function OpsQueuePage() {
+    const today = new Date().toISOString().slice(0, 10);
+
+    const [startDate, setStartDate] = useState(today);
+    const [endDate, setEndDate] = useState(today);
+
+    const [summary, setSummary] = useState(null);
+    const [rows, setRows] = useState([]);
+
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        fetchQueueData(startDate, endDate, true);
+    }, []);
+
+    const getDateRange = (start, end) => {
+        const dates = [];
+        const current = new Date(start);
+        const last = new Date(end);
+
+        while (current <= last) {
+            dates.push(current.toISOString().slice(0, 10));
+            current.setDate(current.getDate() + 1);
+        }
+        return dates;
+    };
+
+    const fetchQueueData = async (from, to, isInitial = false) => {
+        try {
+            setLoading(true);
+            setError("");
+
+            if (from > to) {
+                setError("시작일은 종료일보다 늦을 수 없습니다.");
+                setLoading(false);
+                return;
+            }
+
+            const dates = getDateRange(from, to);
+
+            const [summaryRes, ...hourlyResponses] = await Promise.all([
+                getOpsQueueSummary(),
+                ...dates.map((date) => getOpsQueueHourly({ date }))
+            ]);
+
+            const summaryPayload = summaryRes.data?.data ?? summaryRes.data;
+
+            const mergedRows = [];
+            for (let i = 0; i < hourlyResponses.length; i++) {
+                const payload = hourlyResponses[i].data?.data ?? hourlyResponses[i].data;
+                const targetDate = dates[i];
+
+                if (Array.isArray(payload)) {
+                    payload.forEach((row) => {
+                        mergedRows.push({
+                            date: targetDate,
+                            hour: row.hour,
+                            serviceType: row.serviceType,
+                            queueEnqueuedCount: row.queueEnqueuedCount ?? row.enqueuedCount ?? 0,
+                            queueSuccessCount: row.queueSuccessCount ?? row.successCount ?? 0,
+                            queueFailedCount: row.queueFailedCount ?? row.failedCount ?? 0,
+                            failureRate: row.failureRate ?? 0
+                        });
+                    });
+                }
+            }
+
+            setSummary(summaryPayload);
+            setRows(mergedRows);
+        } catch (e) {
+            console.error("큐 통계 조회 실패:", e);
+            setError("큐 통계를 불러오지 못했습니다.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSearch = (e) => {
+        e.preventDefault();
+        fetchQueueData(startDate, endDate);
+    };
+
+    const handleReset = () => {
+        setStartDate(today);
+        setEndDate(today);
+        fetchQueueData(today, today);
+    };
+
+    const aggregatedByService = useMemo(() => {
+        const map = {};
+
+        rows.forEach((row) => {
+            const key = row.serviceType || "UNKNOWN";
+            if (!map[key]) {
+                map[key] = {
+                    serviceType: key,
+                    queueEnqueuedCount: 0,
+                    queueSuccessCount: 0,
+                    queueFailedCount: 0
+                };
+            }
+
+            map[key].queueEnqueuedCount += row.queueEnqueuedCount ?? 0;
+            map[key].queueSuccessCount += row.queueSuccessCount ?? 0;
+            map[key].queueFailedCount += row.queueFailedCount ?? 0;
+        });
+
+        return Object.values(map).map((item) => ({
+            ...item,
+            failureRate:
+                item.queueEnqueuedCount === 0
+                    ? 0
+                    : item.queueFailedCount / item.queueEnqueuedCount
+        }));
+    }, [rows]);
+
+    const periodTotals = useMemo(() => {
+        const totals = {
+            queueEnqueuedCount: 0,
+            queueSuccessCount: 0,
+            queueFailedCount: 0
+        };
+
+        rows.forEach((row) => {
+            totals.queueEnqueuedCount += row.queueEnqueuedCount ?? 0;
+            totals.queueSuccessCount += row.queueSuccessCount ?? 0;
+            totals.queueFailedCount += row.queueFailedCount ?? 0;
+        });
+
+        return {
+            ...totals,
+            failureRate:
+                totals.queueEnqueuedCount === 0
+                    ? 0
+                    : totals.queueFailedCount / totals.queueEnqueuedCount
+        };
+    }, [rows]);
+
     return (
         <AdminLayout title="Queue 상태">
-            <div>큐 적재, 처리 성공, 실패, 재시도 상태를 표시할 페이지입니다.</div>
+            <Card className="shadow-sm border-0 mb-4">
+                <Card.Body>
+                    <div className="mb-3">
+                        <h5 className="mb-2">큐 상태 안내</h5>
+                        <div className="text-muted" style={{ fontSize: "14px", lineHeight: 1.7 }}>
+                            이 화면은 큐 작업의 전체 상태와 시간대별 처리 흐름을 함께 보여줍니다.
+                            상단 카드는 현재 전체 큐 상태 기준이며,
+                            아래 표와 집계는 선택한 조회 기간 기준입니다.
+                        </div>
+                    </div>
+
+                    <Form onSubmit={handleSearch}>
+                        <Row className="g-3 align-items-end">
+                            <Col md={4}>
+                                <Form.Label>시작일</Form.Label>
+                                <Form.Control
+                                    type="date"
+                                    value={startDate}
+                                    onChange={(e) => setStartDate(e.target.value)}
+                                />
+                            </Col>
+
+                            <Col md={4}>
+                                <Form.Label>종료일</Form.Label>
+                                <Form.Control
+                                    type="date"
+                                    value={endDate}
+                                    onChange={(e) => setEndDate(e.target.value)}
+                                />
+                            </Col>
+
+                            <Col md="auto">
+                                <Button type="submit">조회</Button>
+                            </Col>
+
+                            <Col md="auto">
+                                <Button type="button" variant="secondary" onClick={handleReset}>
+                                    초기화
+                                </Button>
+                            </Col>
+                        </Row>
+                    </Form>
+                </Card.Body>
+            </Card>
+
+            {loading && (
+                <div className="text-center py-5">
+                    <Spinner animation="border" />
+                </div>
+            )}
+
+            {!loading && error && (
+                <Alert variant="danger">{error}</Alert>
+            )}
+
+            {!loading && !error && (
+                <>
+                    <Row className="g-3 mb-4">
+                        <Col md={4} xl={2}>
+                            <SummaryCard
+                                title="현재 대기"
+                                value={summary?.enqueuedCount ?? 0}
+                                subtitle="전체 큐 기준"
+                            />
+                        </Col>
+                        <Col md={4} xl={2}>
+                            <SummaryCard
+                                title="현재 처리 중"
+                                value={summary?.processingCount ?? 0}
+                                subtitle="전체 큐 기준"
+                            />
+                        </Col>
+                        <Col md={4} xl={2}>
+                            <SummaryCard
+                                title="현재 성공"
+                                value={summary?.successCount ?? 0}
+                                subtitle="전체 큐 기준"
+                            />
+                        </Col>
+                        <Col md={4} xl={2}>
+                            <SummaryCard
+                                title="현재 실패"
+                                value={summary?.failedCount ?? 0}
+                                subtitle="전체 큐 기준"
+                            />
+                        </Col>
+                        <Col md={4} xl={2}>
+                            <SummaryCard
+                                title="현재 취소"
+                                value={summary?.cancelledCount ?? 0}
+                                subtitle="전체 큐 기준"
+                            />
+                        </Col>
+                        <Col md={4} xl={2}>
+                            <SummaryCard
+                                title="현재 성공률"
+                                value={
+                                    summary?.successRate != null
+                                        ? `${Number(summary.successRate).toFixed(1)}%`
+                                        : "0.0%"
+                                }
+                                subtitle="전체 큐 기준"
+                            />
+                        </Col>
+                    </Row>
+
+                    <Row className="g-3 mb-4">
+                        <Col md={3}>
+                            <SummaryCard
+                                title="조회 기간 적재"
+                                value={periodTotals.queueEnqueuedCount}
+                                subtitle={`${startDate} ~ ${endDate}`}
+                            />
+                        </Col>
+                        <Col md={3}>
+                            <SummaryCard
+                                title="조회 기간 성공"
+                                value={periodTotals.queueSuccessCount}
+                                subtitle={`${startDate} ~ ${endDate}`}
+                            />
+                        </Col>
+                        <Col md={3}>
+                            <SummaryCard
+                                title="조회 기간 실패"
+                                value={periodTotals.queueFailedCount}
+                                subtitle={`${startDate} ~ ${endDate}`}
+                            />
+                        </Col>
+                        <Col md={3}>
+                            <SummaryCard
+                                title="조회 기간 실패율"
+                                value={`${(periodTotals.failureRate * 100).toFixed(1)}%`}
+                                subtitle={`${startDate} ~ ${endDate}`}
+                            />
+                        </Col>
+                    </Row>
+
+                    <Card className="shadow-sm border-0 mb-4">
+                        <Card.Body>
+                            <Card.Title className="mb-3">서비스별 집계</Card.Title>
+                            <Table striped bordered hover responsive>
+                                <thead>
+                                <tr>
+                                    <th>서비스</th>
+                                    <th>적재</th>
+                                    <th>성공</th>
+                                    <th>실패</th>
+                                    <th>실패율</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {aggregatedByService.length === 0 ? (
+                                    <tr>
+                                        <td colSpan="5" className="text-center">
+                                            조회된 서비스별 집계 데이터가 없습니다.
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    aggregatedByService.map((row) => (
+                                        <tr key={row.serviceType}>
+                                            <td>{row.serviceType}</td>
+                                            <td>{row.queueEnqueuedCount}</td>
+                                            <td>{row.queueSuccessCount}</td>
+                                            <td>{row.queueFailedCount}</td>
+                                            <td>{(row.failureRate * 100).toFixed(1)}%</td>
+                                        </tr>
+                                    ))
+                                )}
+                                </tbody>
+                            </Table>
+                        </Card.Body>
+                    </Card>
+
+                    <Card className="shadow-sm border-0">
+                        <Card.Body>
+                            <Card.Title className="mb-3">시간 단위 큐 현황</Card.Title>
+
+                            <Table striped bordered hover responsive>
+                                <thead>
+                                <tr>
+                                    <th>날짜</th>
+                                    <th>시간</th>
+                                    <th>서비스</th>
+                                    <th>적재</th>
+                                    <th>성공</th>
+                                    <th>실패</th>
+                                    <th>실패율</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {rows.length === 0 ? (
+                                    <tr>
+                                        <td colSpan="7" className="text-center">
+                                            조회된 데이터가 없습니다.
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    rows.map((row, idx) => (
+                                        <tr key={`${row.date}-${row.serviceType}-${row.hour}-${idx}`}>
+                                            <td>{row.date}</td>
+                                            <td>{String(row.hour).padStart(2, "0")}:00</td>
+                                            <td>{row.serviceType}</td>
+                                            <td>{row.queueEnqueuedCount ?? 0}</td>
+                                            <td>{row.queueSuccessCount ?? 0}</td>
+                                            <td>{row.queueFailedCount ?? 0}</td>
+                                            <td>{((row.failureRate ?? 0) * 100).toFixed(1)}%</td>
+                                        </tr>
+                                    ))
+                                )}
+                                </tbody>
+                            </Table>
+
+                            <div className="text-muted mt-2" style={{ fontSize: "13px" }}>
+                                실패율은 적재 대비 실패 비율입니다. 특정 서비스에서 특정 시간대에 실패가 몰리는지 확인할 때 유용합니다.
+                            </div>
+                        </Card.Body>
+                    </Card>
+                </>
+            )}
         </AdminLayout>
+    );
+}
+
+function SummaryCard({ title, value, subtitle }) {
+    return (
+        <Card className="border-0 shadow-sm h-100">
+            <Card.Body>
+                <div className="text-muted" style={{ fontSize: "14px" }}>{title}</div>
+                <div style={{ fontSize: "28px", fontWeight: 700 }}>{value}</div>
+                <div className="text-muted mt-1" style={{ fontSize: "12px" }}>
+                    {subtitle}
+                </div>
+            </Card.Body>
+        </Card>
     );
 }
 


### PR DESCRIPTION
closed: #14 
<br/>

## 📝작업 내용
Admin / Ops 페이지 분리

- Ops 관련 페이지 구조 정리
- - Dashboard
- - Issues
- - Logs
- - Queue
- - Alerts
- AdminSidebar 구조 개선
- admin API 분리 및 정리

<br/>