### PR TITLE
'handleSocialLogin' 함수가  환경변수를 참조하도록 변경

### DIFF
--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -36,8 +36,7 @@ const LoginPage = () => {
     };
 
     const handleSocialLogin = (provider) => {
-        window.location.href = `https://api.synctalk.it.com/oauth2/authorization/${provider}`;
-        // window.location.href = `http://localhost:8081/oauth2/authorization/${provider}`; // 로컬 테스트
+        window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/${provider}`;
     };
 
     return (


### PR DESCRIPTION
## 수정 전

```javascript
const handleSocialLogin = (provider) => {
    window.location.href = `https://api.synctalk.it.com/oauth2/authorization/${provider}`;
    // window.location.href = `http://localhost:8081/oauth2/authorization/${provider}`; // 로컬 테스트
};
```

## 수정 후

```javascript
const handleSocialLogin = (provider) => {
    window.location.href = `${import.meta.env.VITE_API_BASE_URL}/oauth2/authorization/${provider}`;
};
```