### PR TITLE
[FEAT] 에러 이슈 ui 추가 #50

### DIFF
--- a/src/api/ops.js
+++ b/src/api/ops.js
@@ -23,3 +23,6 @@ export const getOpsIssueLogs = (issueId, params) =>
 
 export const getOpsLogDetail = (logId) =>
     api.get(`/admin/logs/${logId}`);
+
+export const updateOpsIssueStatus = (issueId, status) =>
+    api.patch(`/admin/error-issues/${issueId}/status`, { status });

--- a/src/components/admin/ErrorIssueStatusBadge.jsx
+++ b/src/components/admin/ErrorIssueStatusBadge.jsx
@@ -1,0 +1,25 @@
+import { Badge } from "react-bootstrap";
+
+function ErrorIssueStatusBadge({ status }) {
+    const upper = String(status || "").toUpperCase();
+
+    if (upper === "OPEN") {
+        return <Badge bg="danger">OPEN</Badge>;
+    }
+
+    if (upper === "IN_PROGRESS") {
+        return <Badge bg="warning" text="dark">IN_PROGRESS</Badge>;
+    }
+
+    if (upper === "RESOLVED") {
+        return <Badge bg="success">RESOLVED</Badge>;
+    }
+
+    if (upper === "IGNORED") {
+        return <Badge bg="secondary">IGNORED</Badge>;
+    }
+
+    return <Badge bg="secondary">{status || "-"}</Badge>;
+}
+
+export default ErrorIssueStatusBadge;

--- a/src/components/admin/ErrorIssueStatusEditor.jsx
+++ b/src/components/admin/ErrorIssueStatusEditor.jsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { Button, Form } from "react-bootstrap";
+import { updateOpsIssueStatus } from "../../api/ops";
+
+function ErrorIssueStatusEditor({ issueId, currentStatus, onUpdated }) {
+    const [status, setStatus] = useState(currentStatus || "OPEN");
+    const [saving, setSaving] = useState(false);
+
+    const handleSave = async () => {
+        if (status === currentStatus) {
+            return;
+        }
+
+        try {
+            setSaving(true);
+            await updateOpsIssueStatus(issueId, status);
+            onUpdated?.();
+        } catch (error) {
+            console.error("에러 이슈 상태 변경 실패:", error);
+            alert("상태 변경에 실패했습니다.");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="d-flex gap-2 align-items-center">
+            <Form.Select
+                size="sm"
+                value={status}
+                onChange={(e) => setStatus(e.target.value)}
+                disabled={saving}
+            >
+                <option value="OPEN">OPEN</option>
+                <option value="IN_PROGRESS">IN_PROGRESS</option>
+                <option value="RESOLVED">RESOLVED</option>
+                <option value="IGNORED">IGNORED</option>
+            </Form.Select>
+
+            <Button
+                size="sm"
+                variant="outline-primary"
+                onClick={handleSave}
+                disabled={saving}
+            >
+                {saving ? "저장중" : "저장"}
+            </Button>
+        </div>
+    );
+}
+
+export default ErrorIssueStatusEditor;

--- a/src/pages/ops/OpsIssuesPage.jsx
+++ b/src/pages/ops/OpsIssuesPage.jsx
@@ -15,6 +15,8 @@ import {
 import AdminLayout from "../../components/admin/AdminLayout.jsx";
 import { getOpsIssueDetail, getOpsIssues } from "../../api/ops.js";
 import { useNavigate } from "react-router-dom";
+import ErrorIssueStatusBadge from "../../components/admin/ErrorIssueStatusBadge.jsx";
+import ErrorIssueStatusEditor from "../../components/admin/ErrorIssueStatusEditor.jsx";
 
 function OpsIssuesPage() {
     const navigate = useNavigate();
@@ -132,6 +134,7 @@ function OpsIssuesPage() {
                                     <option value="OPEN">OPEN</option>
                                     <option value="IN_PROGRESS">IN_PROGRESS</option>
                                     <option value="RESOLVED">RESOLVED</option>
+                                    <option value="IGNORED">IGNORED</option>
                                 </Form.Select>
                             </Col>
 
@@ -160,13 +163,17 @@ function OpsIssuesPage() {
                                     }
                                 >
                                     <option value="">전체</option>
+                                    <option value="GLOBAL">GLOBAL</option>
                                     <option value="AUTH">AUTH</option>
                                     <option value="RESUME">RESUME</option>
                                     <option value="INTERVIEW">INTERVIEW</option>
+                                    <option value="JOB_POSTING">JOB_POSTING</option>
                                     <option value="FILE">FILE</option>
-                                    <option value="ADMIN">ADMIN</option>
                                     <option value="STATISTICS">STATISTICS</option>
-                                    <option value="GLOBAL">GLOBAL</option>
+                                    <option value="ADMIN">ADMIN</option>
+                                    <option value="QUEUE">QUEUE</option>
+                                    <option value="EXTERNAL_API">EXTERNAL_API</option>
+                                    <option value="SYSTEM">SYSTEM</option>
                                 </Form.Select>
                             </Col>
 
@@ -220,13 +227,15 @@ function OpsIssuesPage() {
                                     <th>도메인</th>
                                     <th>발생 횟수</th>
                                     <th>최근 발생</th>
+                                    <th>보조 표시</th>
+                                    <th>상태 변경</th>
                                     <th>액션</th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 {issues.length === 0 ? (
                                     <tr>
-                                        <td colSpan="9" className="text-center">
+                                        <td colSpan="11" className="text-center">
                                             조회된 이슈가 없습니다.
                                         </td>
                                     </tr>
@@ -240,7 +249,7 @@ function OpsIssuesPage() {
                                                 <SeverityBadge severity={issue.severity} />
                                             </td>
                                             <td>
-                                                <StatusBadge status={issue.status} />
+                                                <ErrorIssueStatusBadge status={issue.status} />
                                             </td>
                                             <td>{issue.errorDomain}</td>
                                             <td>{issue.occurrenceCount}</td>
@@ -248,6 +257,18 @@ function OpsIssuesPage() {
                                                 {issue.lastOccurredAt
                                                     ? new Date(issue.lastOccurredAt).toLocaleString("ko-KR")
                                                     : "-"}
+                                            </td>
+                                            <td>
+                                                <span className={issue.recentlyOccurred ? "text-danger fw-semibold" : "text-muted"}>
+                                                    {issue.statusHint || "-"}
+                                                </span>
+                                            </td>
+                                            <td style={{ minWidth: "220px" }}>
+                                                <ErrorIssueStatusEditor
+                                                    issueId={issue.issueId}
+                                                    currentStatus={issue.status}
+                                                    onUpdated={() => fetchIssues(pageInfo.number, filters)}
+                                                />
                                             </td>
                                             <td className="d-flex gap-2 flex-wrap">
                                                 <Button
@@ -299,15 +320,6 @@ function SeverityBadge({ severity }) {
     else if (severity === "LOW") bg = "success";
 
     return <Badge bg={bg}>{severity}</Badge>;
-}
-
-function StatusBadge({ status }) {
-    let bg = "secondary";
-    if (status === "OPEN") bg = "danger";
-    else if (status === "IN_PROGRESS") bg = "warning";
-    else if (status === "RESOLVED") bg = "success";
-
-    return <Badge bg={bg}>{status}</Badge>;
 }
 
 function PagingBar({ pageInfo, onMove }) {


### PR DESCRIPTION
closed: #50 

## 작업 내용
- 에러 이슈 상태 표시 배지 컴포넌트 추가 (ErrorIssueStatusBadge)
- 에러 이슈 상태 변경 UI 추가 (ErrorIssueStatusEditor)
- OpsIssuesPage에 상태 변경 기능 및 보조 표시(statusHint, recentlyOccurred) 반영
- ops API에 상태 변경 요청 함수 추가

## 목적
- 운영자가 에러 이슈 상태를 UI에서 직접 관리할 수 있도록 개선
- 최근 발생 여부 및 상태 힌트를 통해 빠른 판단 가능하도록 개선

## 변경 파일
- src/api/ops.js
- src/pages/ops/OpsIssuesPage.jsx
- src/components/admin/ErrorIssueStatusBadge.jsx
- src/components/admin/ErrorIssueStatusEditor.jsx